### PR TITLE
Update code to use Gemini API instead of OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,34 @@ The tool now includes a feature that asks the user additional questions if the t
 
 # TODO:
 The AI needs to ask additional questions about their task if they provide a task too general, and it needs to find information directly from the website to determine if it is productive for the task.
+
+# Installation
+
+To use the Gemini API, you need to install the `google-genai` package. You can do this using pip:
+
+```sh
+pip install -q -U google-genai
+```
+
+# Obtaining a Gemini API Key
+
+To use the Gemini API, you need to obtain an API key from Google AI Studio. Follow these steps:
+
+1. Go to the [Google AI Studio](https://ai.google.com/studio) website.
+2. Sign in with your Google account.
+3. Navigate to the API section and generate a new API key.
+4. Copy the API key and use it in your code.
+
+# Example Code
+
+Here is an example of how to use the Gemini API to generate content:
+
+```python
+from google import genai
+
+client = genai.Client(api_key="YOUR_API_KEY")
+response = client.models.generate_content(
+    model="gemini-2.0-flash", contents="Explain how AI works"
+)
+print(response.text)
+```

--- a/tool.py
+++ b/tool.py
@@ -1,6 +1,6 @@
-import openai
 import requests
 from bs4 import BeautifulSoup
+from google import genai
 
 def get_user_task():
     task = input("Please enter the task you want to achieve: ")
@@ -10,12 +10,11 @@ def get_user_task():
 
 def is_task_too_general(task):
     # Placeholder for logic to determine if the task is too general
-    response = openai.Completion.create(
-        engine="text-davinci-003",
-        prompt=f"Is the task '{task}' too general?",
-        max_tokens=10
+    client = genai.Client(api_key="YOUR_API_KEY")
+    response = client.models.generate_content(
+        model="gemini-2.0-flash", contents=f"Is the task '{task}' too general?"
     )
-    return response.choices[0].text.strip().lower() == "yes"
+    return response.text.strip().lower() == "yes"
 
 def ask_additional_questions(task):
     additional_info = input("Your task seems too general. Can you provide more details? ")
@@ -32,12 +31,11 @@ def get_website_info(website):
 
 def determine_relevance(task, website):
     website_info = get_website_info(website)
-    response = openai.Completion.create(
-        engine="text-davinci-003",
-        prompt=f"Is the website {website} relevant for the task {task}? Here is some information from the website: {website_info}",
-        max_tokens=10
+    client = genai.Client(api_key="YOUR_API_KEY")
+    response = client.models.generate_content(
+        model="gemini-2.0-flash", contents=f"Is the website {website} relevant for the task {task}? Here is some information from the website: {website_info}"
     )
-    relevance = response.choices[0].text.strip().lower()
+    relevance = response.text.strip().lower()
     return relevance == "yes"
 
 def main():


### PR DESCRIPTION
Update the code to use the Gemini API instead of the OpenAI API for generating content.

* **README.md**
  - Add instructions for installing the `google-genai` package using pip.
  - Add instructions for obtaining a Gemini API key in Google AI Studio.
  - Add example code for using the Gemini API to generate content.

* **tool.py**
  - Replace `openai` import with `google-genai` import.
  - Update `is_task_too_general` function to use `genai.Client` for determining if a task is too general.
  - Update `determine_relevance` function to use `genai.Client` for determining the relevance of a website for a given task.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/distracting-websites/pull/3?shareId=4e14246f-8ba5-4371-b3e4-476602185959).